### PR TITLE
fix(remoteitems): fix direct request of remote items  (#191)

### DIFF
--- a/integrationtests/FSXAProxyApi.test.ts
+++ b/integrationtests/FSXAProxyApi.test.ts
@@ -5,6 +5,7 @@ import {
   FSXAContentMode,
   FSXAProxyApi,
   LogLevel,
+  Image,
   Page,
   QueryBuilderQuery,
   Reference,
@@ -487,6 +488,24 @@ describe('FSXAProxyAPI', () => {
       expect(mappedRef.referenceRemoteProject).toEqual(
         remotePageRefReference.value?.remoteProject
       )
+    })
+    it('api returns remote element if directly requested', async function () {
+      const remoteMedia = createMediaPicture(undefined, "de_DE")
+      
+      await caasClient.addDocToCollection({
+        ...remoteMedia,
+        locale: {
+          identifier: 'de',
+          country: 'DE',
+          language: 'de',
+        },
+      })
+      const res: Image = await proxyAPI.fetchElement({
+        id: remoteMedia.identifier,
+        locale: 'de_DE',
+      })
+      expect(res).toBeDefined
+      expect(res.id).toBe(remoteMedia.identifier)
     })
   })
 

--- a/src/modules/CaaSMapper.ts
+++ b/src/modules/CaaSMapper.ts
@@ -1036,7 +1036,7 @@ export class CaaSMapper {
 
     // find resolved refs and puzzle them back together
     const mappedItems = findResolvedReferencesByIds(
-      items.map((item) => getItemId(item)),
+      items.map((item) => getItemId(item, remoteProjectId)),
       this.resolvedReferences
     )
 

--- a/src/modules/FSXAProxyApi.spec.ts
+++ b/src/modules/FSXAProxyApi.spec.ts
@@ -13,7 +13,7 @@ describe('FSXAProxyAPI', () => {
   beforeEach(() => {
     fetchMock.resetMocks()
     id = Faker.datatype.uuid()
-    locale = Faker.locale
+    locale = `${Faker.locale}_${Faker.locale.toUpperCase()}`
   })
   describe('The initialization', () => {
     it('should throw an error if the BASEURL is empty', () => {

--- a/src/modules/FSXAProxyApi.ts
+++ b/src/modules/FSXAProxyApi.ts
@@ -148,7 +148,8 @@ export class FSXAProxyApi implements FSXAApi {
     mappedItems = denormalizeResolvedReferences(
       mappedItems,
       referenceMap,
-      resolvedReferences
+      resolvedReferences,
+      remoteProject
     )
 
     return mappedItems[0] as unknown as T
@@ -251,7 +252,8 @@ export class FSXAProxyApi implements FSXAApi {
     items = denormalizeResolvedReferences(
       items as (CaasApi_Item | MappedCaasItem)[],
       referenceMap!,
-      resolvedReferences!
+      resolvedReferences!,
+      remoteProject
     )
 
     return { page, pagesize, totalPages, size, items } as FetchResponse

--- a/src/modules/FSXARemoteApi.ts
+++ b/src/modules/FSXARemoteApi.ts
@@ -460,6 +460,11 @@ export class FSXARemoteApi implements FSXAApi {
       remoteProject && this.remotes
         ? this.remotes[remoteProject]?.locale
         : locale
+
+    const remoteProjectId = remoteProject
+      ? this.remotes[remoteProject]?.id
+      : undefined
+
     const {
       items,
       referenceMap = {},
@@ -473,7 +478,7 @@ export class FSXARemoteApi implements FSXAApi {
         },
       ],
       additionalParams,
-      remoteProject,
+      remoteProject: remoteProjectId,
       fetchOptions,
       filterContext,
       normalized: true,
@@ -489,7 +494,8 @@ export class FSXARemoteApi implements FSXAApi {
       : denormalizeResolvedReferences(
           items as (MappedCaasItem | CaasApi_Item)[],
           referenceMap,
-          resolvedReferences
+          resolvedReferences,
+          remoteProjectId
         )[0]
   }
 
@@ -661,7 +667,8 @@ export class FSXARemoteApi implements FSXAApi {
         : denormalizeResolvedReferences(
             mappedItems,
             referenceMap,
-            resolvedReferences
+            resolvedReferences,
+            remoteProjectId
           ),
       ...(normalized && { referenceMap }),
       ...(normalized && { resolvedReferences }),

--- a/src/modules/MappingUtils.ts
+++ b/src/modules/MappingUtils.ts
@@ -72,7 +72,8 @@ const imageMapForceResolution = ({
 const denormalizeResolvedReferences = (
   mappedItems: (CaasApi_Item | MappedCaasItem)[],
   referenceMap: ReferencedItemsInfo,
-  resolvedReferences: ResolvedReferencesInfo
+  resolvedReferences: ResolvedReferencesInfo,
+  remoteProjectId?: string
 ) => {
   if (!referenceMap || Object.keys(referenceMap).length === 0)
     return mappedItems
@@ -104,7 +105,7 @@ const denormalizeResolvedReferences = (
   // update mappedItems
   const queriedIds = mappedItems
     .filter((item) => !!item)
-    .map((item) => getItemId(item))
+    .map((item) => getItemId(item, remoteProjectId))
 
   return findResolvedReferencesByIds(queriedIds, resolvedReferences)
 }

--- a/src/testutils/generateRandomConfig.ts
+++ b/src/testutils/generateRandomConfig.ts
@@ -12,8 +12,14 @@ export const generateRandomConfig = () => {
     ? FSXAContentMode.PREVIEW
     : FSXAContentMode.RELEASE
   const REMOTES = {
-    remote: { id: Faker.datatype.uuid(), locale: Faker.locale },
-    secondRemote: { id: Faker.datatype.uuid(), locale: Faker.locale },
+    remote: {
+      id: Faker.datatype.uuid(),
+      locale: `${Faker.locale}_${Faker.locale.toUpperCase()}`,
+    },
+    secondRemote: {
+      id: Faker.datatype.uuid(),
+      locale: `${Faker.locale}_${Faker.locale.toUpperCase()}`,
+    },
   }
 
   return {

--- a/src/testutils/getMappedMediaPicture.ts
+++ b/src/testutils/getMappedMediaPicture.ts
@@ -4,14 +4,12 @@ export const getMappedMediaPicture = (
   caasMedia: CaaSApi_Media_Picture,
   locale: string,
   remoteProjectId?: string
-): Image => {
-  return {
-    type: 'Image',
-    id: caasMedia.identifier,
-    previewId: `${caasMedia.identifier}.${locale}`,
-    meta: {},
-    description: caasMedia.description,
-    resolutions: {},
-    remoteProjectId,
-  }
-}
+): Image => ({
+  type: "Image",
+  id: caasMedia.identifier,
+  previewId: `${caasMedia.identifier}.${locale}`,
+  meta: {},
+  description: caasMedia.description,
+  resolutions: {},
+  remoteProjectId
+})

--- a/src/testutils/getMappedMediaPicture.ts
+++ b/src/testutils/getMappedMediaPicture.ts
@@ -1,0 +1,17 @@
+import { CaaSApi_Media_Picture, Image } from '../types'
+
+export const getMappedMediaPicture = (
+  caasMedia: CaaSApi_Media_Picture,
+  locale: string,
+  remoteProjectId?: string
+): Image => {
+  return {
+    type: 'Image',
+    id: caasMedia.identifier,
+    previewId: `${caasMedia.identifier}.${locale}`,
+    meta: {},
+    description: caasMedia.description,
+    resolutions: {},
+    remoteProjectId,
+  }
+}


### PR DESCRIPTION
* fix(remoteitems): fix direct request od remote items

When requesting Remote items directly (opposed to indirectly as reference of another requested local item), those remote items were not correctly handled. 
This led to empty responses, even though the item itself was correctly fetched and put into resolvedReferences
