### PR TITLE
Make regex validation filter optional

### DIFF
--- a/src/modules/QueryBuilder.spec.ts
+++ b/src/modules/QueryBuilder.spec.ts
@@ -831,6 +831,20 @@ describe('QueryBuilder', () => {
           })
         ).toThrow(QueryBuilderErrors.INVALID_REGEX)
       })
+      it('should not throw an error if regex string is invalid if validateRegex is false', () => {
+        expect(
+          builder.build({
+            operator: EvaluationQueryOperatorEnum.REGEX,
+            value: '[',
+            field: foobar,
+            validateRegex: false,
+          })
+        ).toEqual({
+          foobar: {
+            [EvaluationQueryOperatorEnum.REGEX]: '[',
+          },
+        })
+      })
       it('simple test', () => {
         expect(
           builder.build({

--- a/src/modules/QueryBuilder.ts
+++ b/src/modules/QueryBuilder.ts
@@ -116,7 +116,7 @@ export class QueryBuilder {
         if (typeof filter.value !== 'string')
           throw new Error(QueryBuilderErrors.NOT_A_STRING)
         // throw error if regex is invalid
-        if (!isValidRegex(filter.value))
+        if (filter.validateRegex !== false && !isValidRegex(filter.value))
           throw new Error(QueryBuilderErrors.INVALID_REGEX)
         return {
           [filter.field]: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -902,6 +902,7 @@ export type EvaluationFilter = {
   field: string
   operator: EvaluationQueryOperatorEnum.REGEX
   value: string
+  validateRegex?: boolean
 }
 
 export type QueryBuilderQuery =


### PR DESCRIPTION
This PR allow the user to skip the javascript regex validation for filters. Filters in the ContentAPI are not necessarily compatible with JavaScript Regex. For example `(?i).*example.*` works in ContentAPI but not in JavaScript.